### PR TITLE
Composer install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /tmp/analytics.log
 /tmp/
 /.idea/
+/vendor/

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,23 @@
+{
+	"name": "omgwtfwow/segment-for-wp-by-in8-io",
+	"description": "Segment Analytics for WordPress.",
+	"type": "wordpress-plugin",
+	"homepage": "https://github.com/omgwtfwow/segment-for-wp-by-in8-io",
+	"readme": "https://githubhttps://github.com/omgwtfwow/segment-for-wp-by-in8-io/blob/master/README.md",
+	"license": "GPL-2.0-or-later",
+	"authors": [
+		{
+			"name": "juanin8",
+      "homepage": "https://www.juangonzalez.com.au",
+			"role": "Developer"
+		},
+		{
+			"name": "Enrico Deleo",
+			"homepage": "https://enricodeleo.com",
+			"role": "Developer"
+		}
+	],
+	"require": {
+		"php": ">=7.0"
+	}
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,20 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "9bce913090bf7c0f5d6ccb5ef03727b3",
+    "packages": [],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=7.0"
+    },
+    "platform-dev": [],
+    "plugin-api-version": "2.1.0"
+}


### PR DESCRIPTION
Composer file is needed in order to install this plugin via GitHub and composer. Such a practice is well established among developers who use Wordpress as a foundation for their php applications. Lots fo Wordpress development kits such as my [wpacked](https://github.com/enricodeleo/wpacked) leverage composer and `composer/installers` for such a goal.